### PR TITLE
got rid of compression

### DIFF
--- a/.github/workflows/prod_backup.yaml
+++ b/.github/workflows/prod_backup.yaml
@@ -24,9 +24,6 @@ jobs:
           mkdir -p backups
           pg_dump postgresql://postgres.${{ secrets.PROD_DB_URL }}:${PG_PASSWORD}@aws-0-us-west-1.pooler.supabase.com:5432/postgres -f backups/prod_backup_${{ steps.date.outputs.date }}.sql
 
-      - name: Compress backup
-        run: tar -czf prod_backup_${{ steps.date.outputs.date }}.tar.gz -C backups .
-
       - name: Upload backup artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
the final workflow, dumps prod database and uploads as an artifact for 90 days

didn't think compression was necessary for 1 sql file. backup from prod manually

fixes issue #130 