### PR TITLE
update: added preference settings for onboarding inside profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.yarn/releases
 !.yarn/versions
 .claude
+CLAUDE.md
 
 # testing
 /coverage

--- a/docs/superpowers/plans/2026-04-12-profile-preferences.md
+++ b/docs/superpowers/plans/2026-04-12-profile-preferences.md
@@ -1,0 +1,1103 @@
+# Profile Preferences Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Preferences" section to the profile page sidebar where users can edit the academic info, current clubs, and interest categories they set during onboarding.
+
+**Architecture:** A new `PreferencesSection` component pre-fills from data already loaded by the profile page (extended to include `user_interests`). Saves via a new `PATCH /api/onboarding` handler. The onboarding `Interests.js` step is also finished using a new `interests.json` data file, and `Clubs.js` is updated to search live clubs from the API.
+
+**Tech Stack:** Next.js App Router, React 19, Tailwind CSS v4, Supabase, Jest + @testing-library/react
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/app/onboarding/data/interests.json` | Create | Subcategory data keyed by broad category |
+| `src/app/onboarding/components/MultiSelectSearch.js` | Modify | Add `onQueryChange` + `serverSearch` props for live API search |
+| `src/app/onboarding/steps/Interests.js` | Replace | Finish WIP step using `interests.json` |
+| `src/app/onboarding/steps/Clubs.js` | Replace | Live debounced search against `/api/clubs` |
+| `src/app/api/onboarding/route.js` | Modify | Add `PATCH` handler to update preferences |
+| `src/app/api/profile/route.js` | Modify | Add `user_interests` flat array to GET response |
+| `src/app/profile/components/PreferencesSection.js` | Create | Full preferences editing form |
+| `src/app/profile/page.js` | Modify | Add Preferences sidebar section; wire up PreferencesSection |
+
+---
+
+## Task 1: Create interests.json and verify its structure with a test
+
+**Files:**
+- Create: `src/app/onboarding/data/interests.json`
+- Create: `src/app/onboarding/data/interests.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/app/onboarding/data/interests.test.js`:
+```js
+import INTERESTS from './interests.json';
+
+const BROAD_CATEGORIES = [
+  "Academic & Pre-Professional",
+  "Cultural & Identity-Based",
+  "Community & Advocacy",
+  "Arts & Media",
+  "Health & Wellness",
+  "Spiritual & Religious",
+  "Campus Life & Social",
+];
+
+describe('interests.json', () => {
+  test('has exactly the 7 expected broad categories', () => {
+    expect(Object.keys(INTERESTS)).toHaveLength(7);
+    BROAD_CATEGORIES.forEach(cat => {
+      expect(INTERESTS).toHaveProperty(cat);
+    });
+  });
+
+  test('each category has at least 3 subcategories', () => {
+    BROAD_CATEGORIES.forEach(cat => {
+      expect(Array.isArray(INTERESTS[cat])).toBe(true);
+      expect(INTERESTS[cat].length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  test('all subcategories are non-empty strings', () => {
+    Object.values(INTERESTS).flat().forEach(sub => {
+      expect(typeof sub).toBe('string');
+      expect(sub.trim().length).toBeGreaterThan(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails because the file doesn't exist yet**
+
+```bash
+npx jest src/app/onboarding/data/interests.test.js --no-coverage
+```
+Expected: FAIL — `Cannot find module './interests.json'`
+
+- [ ] **Step 3: Create the data file**
+
+`src/app/onboarding/data/interests.json`:
+```json
+{
+  "Academic & Pre-Professional": [
+    "Pre-Law",
+    "Pre-Med / Pre-Health",
+    "Business & Finance",
+    "Engineering & Computer Science",
+    "Research & Science",
+    "Education & Tutoring",
+    "Consulting"
+  ],
+  "Cultural & Identity-Based": [
+    "Asian & Pacific Islander",
+    "Black & African American",
+    "Latin & Hispanic",
+    "Middle Eastern & North African",
+    "South Asian",
+    "LGBTQ+",
+    "Women & Gender"
+  ],
+  "Community & Advocacy": [
+    "Environmental & Sustainability",
+    "Social Justice",
+    "Volunteering & Service",
+    "Political & Civic Engagement",
+    "Mental Health Awareness",
+    "Housing & Food Security"
+  ],
+  "Arts & Media": [
+    "Visual Arts & Design",
+    "Music & Performance",
+    "Film & Photography",
+    "Journalism & Writing",
+    "Dance",
+    "Theater & Acting"
+  ],
+  "Health & Wellness": [
+    "Fitness & Sports",
+    "Martial Arts",
+    "Outdoors & Adventure",
+    "Mental Health",
+    "Nutrition & Cooking"
+  ],
+  "Spiritual & Religious": [
+    "Christian",
+    "Jewish",
+    "Muslim",
+    "Hindu & Buddhist",
+    "Interfaith & Secular"
+  ],
+  "Campus Life & Social": [
+    "Greek Life",
+    "Gaming & Esports",
+    "Hobby & Interest Groups",
+    "Leadership & Student Government",
+    "Networking & Professional",
+    "Cultural Events"
+  ]
+}
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+```bash
+npx jest src/app/onboarding/data/interests.test.js --no-coverage
+```
+Expected: PASS — 3 tests
+
+---
+
+## Task 2: Add server-side search support to MultiSelectSearch
+
+**Files:**
+- Modify: `src/app/onboarding/components/MultiSelectSearch.js`
+
+The component needs two new optional props so `Clubs.js` and `PreferencesSection` can drive search via the API rather than filtering a static array client-side:
+- `onQueryChange(query)` — called on every keystroke so the parent can debounce + fetch
+- `serverSearch` (boolean, default `false`) — when `true`, skips the internal `.filter()` step and uses `options` as-is (the parent provides pre-filtered results)
+
+No new test needed — the existing behavior for all current callers is unchanged (both props are optional and default to the current behavior).
+
+- [ ] **Step 1: Update MultiSelectSearch**
+
+Replace the entire file `src/app/onboarding/components/MultiSelectSearch.js` with:
+
+```js
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { IoClose } from "react-icons/io5";
+
+export default function MultiSelectSearch({
+  label,
+  placeholder = "Search...",
+  options = [],
+  selected = [],
+  onSelect,
+  onRemove,
+  required = false,
+  onQueryChange,   // optional: called with the raw query string on every keystroke
+  serverSearch = false, // when true, skip client-side filtering (parent provides pre-filtered options)
+}) {
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  const lowerQuery = query.toLowerCase();
+
+  const filtered = serverSearch
+    ? options.filter((o) => !selected.includes(o)).slice(0, 8)
+    : query.trim() === ""
+      ? []
+      : options
+          .filter((o) => !selected.includes(o))
+          .filter((o) => o.toLowerCase().includes(lowerQuery))
+          .sort((a, b) => {
+            const indexA = a.toLowerCase().indexOf(lowerQuery);
+            const indexB = b.toLowerCase().indexOf(lowerQuery);
+            if (indexA !== indexB) return indexA - indexB;
+            return a.toLowerCase().localeCompare(b.toLowerCase());
+          })
+          .slice(0, 8);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (option) => {
+    onSelect(option);
+    setQuery("");
+    if (onQueryChange) onQueryChange("");
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-semibold text-gray-800">
+        {label}
+        {required && <span className="text-[#FFA1CD] ml-0.5">*</span>}
+      </label>
+
+      <div className="relative" ref={containerRef}>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+            if (onQueryChange) onQueryChange(e.target.value);
+          }}
+          onFocus={() => setIsOpen(true)}
+          placeholder={placeholder}
+          className="w-full rounded-full bg-[#F4F5F6] py-3 pl-5 pr-12 text-sm text-gray-700 hover:bg-[#E5EBF1] focus:bg-[#E5EBF1] focus:outline-none"
+        />
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-4">
+          <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </div>
+
+        {isOpen && filtered.length > 0 && (
+          <ul className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-xl bg-white py-1 text-sm shadow-lg">
+            {filtered.map((option) => (
+              <li
+                key={option}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => handleSelect(option)}
+                className="cursor-pointer truncate px-4 py-2 hover:bg-[#F4F5F6]"
+              >
+                {option}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {isOpen && query.trim() && filtered.length === 0 && (
+          <div className="absolute z-10 mt-1 w-full rounded-xl bg-white px-4 py-3 text-sm text-gray-500 shadow-lg">
+            No results for &quot;{query}&quot;
+          </div>
+        )}
+      </div>
+
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selected.map((item) => (
+            <span
+              key={item}
+              className="flex items-center gap-1 rounded-full border border-[#FFA1CD] bg-[#FFCEE5] px-3 py-1 text-sm text-gray-800"
+            >
+              {item}
+              <button
+                onClick={() => onRemove(item)}
+                className="ml-0.5 text-gray-500 hover:text-gray-700"
+                aria-label={`Remove ${item}`}
+              >
+                <IoClose size={13} />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the app still builds cleanly (no TypeScript/ESLint errors)**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 3: Finish the Interests.js onboarding step
+
+**Files:**
+- Replace: `src/app/onboarding/steps/Interests.js`
+
+The step shows subcategories grouped by whichever broad categories the user selected in the previous step (`formData.interests`). Selecting/deselecting a subcategory calls `onUpdate({ subcategories: updated })`. The step is optional — `onValidChange(true)` always.
+
+- [ ] **Step 1: Replace Interests.js**
+
+`src/app/onboarding/steps/Interests.js`:
+```js
+"use client";
+
+import { useEffect, useState } from "react";
+import INTERESTS from "../data/interests.json";
+
+export default function Interests({ formData, onUpdate, onValidChange }) {
+  const [selected, setSelected] = useState(formData.subcategories ?? []);
+  const selectedCategories = formData.interests ?? [];
+
+  useEffect(() => {
+    onValidChange(true); // optional step — always allow advancing
+  }, []);
+
+  const toggle = (subcategory) => {
+    const updated = selected.includes(subcategory)
+      ? selected.filter((s) => s !== subcategory)
+      : [...selected, subcategory];
+    setSelected(updated);
+    onUpdate({ subcategories: updated });
+  };
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Dive deeper into your interests!</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Select any specific areas you&apos;re interested in. This step is optional.
+        </p>
+      </div>
+
+      {selectedCategories.length === 0 ? (
+        <p className="text-sm text-gray-400">
+          Go back and select interest categories to see subcategories here.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {selectedCategories.map((category) => (
+            <div key={category}>
+              <h2 className="mb-2 text-sm font-semibold text-gray-600">{category}</h2>
+              <div className="flex flex-wrap gap-2">
+                {(INTERESTS[category] ?? []).map((sub) => {
+                  const isSelected = selected.includes(sub);
+                  return (
+                    <button
+                      key={sub}
+                      onClick={() => toggle(sub)}
+                      className={`rounded-full px-4 py-2 text-sm font-medium ${
+                        isSelected
+                          ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                          : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                      }`}
+                    >
+                      {sub}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 4: Fix Clubs.js with live API search
+
+**Files:**
+- Replace: `src/app/onboarding/steps/Clubs.js`
+
+Replaces the hardcoded `TEMP_CLUBS` array with a debounced search against `GET /api/clubs?name=<query>&page=1&sort=alphabetical`. The API returns `{ orgList: [...] }` where each item has an `OrganizationName` string. The debounce is 300ms, implemented with `useRef` to avoid stale closure issues.
+
+- [ ] **Step 1: Replace Clubs.js**
+
+`src/app/onboarding/steps/Clubs.js`:
+```js
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import MultiSelectSearch from "../components/MultiSelectSearch";
+
+export default function Clubs({ formData, onUpdate, onValidChange }) {
+  const [selectedClubs, setSelectedClubs] = useState(formData.clubs ?? []);
+  const [clubOptions, setClubOptions] = useState([]);
+  const debounceRef = useRef(null);
+
+  useEffect(() => {
+    onValidChange(true); // optional step
+  }, []);
+
+  const handleQueryChange = (query) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setClubOptions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/clubs?name=${encodeURIComponent(query)}&page=1&sort=alphabetical`
+        );
+        const data = await res.json();
+        setClubOptions((data.orgList || []).map((c) => c.OrganizationName));
+      } catch {
+        setClubOptions([]);
+      }
+    }, 300);
+  };
+
+  const handleSelect = (club) => {
+    const updated = [...selectedClubs, club];
+    setSelectedClubs(updated);
+    onUpdate({ clubs: updated });
+  };
+
+  const handleRemove = (club) => {
+    const updated = selectedClubs.filter((c) => c !== club);
+    setSelectedClubs(updated);
+    onUpdate({ clubs: updated });
+  };
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Which clubs are you in?</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          We&apos;ll be using this information to personalize club recommendations for you.
+        </p>
+        <p className="mt-1 text-xs text-[#6E808D]">
+          Not now? You can always fill this out later from your profile page.
+        </p>
+      </div>
+
+      <MultiSelectSearch
+        label="Select your club(s)"
+        placeholder="Search clubs..."
+        options={clubOptions}
+        selected={selectedClubs}
+        onSelect={handleSelect}
+        onRemove={handleRemove}
+        onQueryChange={handleQueryChange}
+        serverSearch
+      />
+
+      {selectedClubs.length === 0 && (
+        <p className="-mt-4 text-xs text-gray-400">
+          Not in any clubs yet? You can skip this step.
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 5: Add PATCH handler to /api/onboarding
+
+**Files:**
+- Modify: `src/app/api/onboarding/route.js`
+
+The `PATCH` handler accepts the same body shape as the existing `POST` but does not touch `onboarding_completed`. It updates `majors`, `minors`, `current_clubs` on `profiles` and replaces all `user_interests` rows for the user.
+
+- [ ] **Step 1: Add the PATCH export to the end of the file**
+
+Open `src/app/api/onboarding/route.js` and append after the closing brace of the `POST` export:
+
+```js
+// PATCH /api/onboarding
+// Updates user preferences without changing onboarding_completed.
+// Body: { majors, minors, broadCategories, subcategories, currentClubs }
+export async function PATCH(req) {
+  try {
+    const supabase = await createAuthenticatedClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { majors = [], minors = [], broadCategories = [], subcategories = [], currentClubs = [] } = await req.json();
+
+    const { error: profileError } = await supabaseServer
+      .from("profiles")
+      .update({
+        majors,
+        minors,
+        current_clubs: currentClubs,
+      })
+      .eq("id", user.id);
+
+    if (profileError) {
+      return Response.json({ error: "Failed to save profile preferences" }, { status: 500 });
+    }
+
+    // Always delete existing interests first, then re-insert if any selected.
+    await supabaseServer
+      .from("user_interests")
+      .delete()
+      .eq("user_id", user.id);
+
+    const allInterests = [...new Set([...broadCategories, ...subcategories])];
+
+    if (allInterests.length > 0) {
+      const { error: interestsError } = await supabaseServer
+        .from("user_interests")
+        .insert(allInterests.map((category) => ({ user_id: user.id, category })));
+
+      if (interestsError) {
+        return Response.json({ error: "Failed to save interest preferences" }, { status: 500 });
+      }
+    }
+
+    return Response.json({ success: true });
+  } catch {
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 6: Add user_interests to GET /api/profile
+
+**Files:**
+- Modify: `src/app/api/profile/route.js`
+
+Add a `user_interests` query and include a flat array of category strings in the response. The profile page uses this to pre-fill the Preferences form.
+
+- [ ] **Step 1: Add the user_interests fetch**
+
+In `src/app/api/profile/route.js`, add the following query after the `savedClubsData` fetch (around line 76), before the transformation block:
+
+```js
+    // Fetch user interests
+    const { data: userInterestsData, error: interestsError } = await supabase
+      .from('user_interests')
+      .select('category')
+      .eq('user_id', userId);
+
+    if (interestsError) {
+      console.error('Error fetching user interests:', interestsError);
+    }
+```
+
+- [ ] **Step 2: Add userInterests to the return payload**
+
+In the same file, find the `return new Response(JSON.stringify({...}), ...)` block and add `userInterests` to the object:
+
+```js
+    return new Response(
+      JSON.stringify({
+        profile: profileData,
+        approvedReviews: approvedReviews || [],
+        pendingReviews: pendingReviews || [],
+        rejectedReviews: rejectedReviews || [],
+        likedClubs: likedClubsWithCounts,
+        savedClubs: savedClubsWithCounts,
+        unreadRejectedCount,
+        userInterests: (userInterestsData || []).map((row) => row.category),
+      }),
+      { status: 200 }
+    );
+```
+
+- [ ] **Step 3: Verify lint passes**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 7: Create PreferencesSection with splitUserInterests utility and test
+
+**Files:**
+- Create: `src/app/profile/components/PreferencesSection.js`
+- Create: `src/app/profile/components/PreferencesSection.test.js`
+
+`splitUserInterests` is a pure function exported from `PreferencesSection.js`. It splits a flat `user_interests` array (as returned by the profile API) into `broadCategories` (strings that match any of the 7 category keys in `interests.json`) and `subcategories` (everything else).
+
+- [ ] **Step 1: Write the failing test for splitUserInterests**
+
+`src/app/profile/components/PreferencesSection.test.js`:
+```js
+import { splitUserInterests } from './PreferencesSection';
+
+describe('splitUserInterests', () => {
+  test('separates broad categories from subcategories', () => {
+    const input = ["Arts & Media", "Dance", "Pre-Law", "Academic & Pre-Professional"];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toEqual(["Arts & Media", "Academic & Pre-Professional"]);
+    expect(subcategories).toEqual(["Dance", "Pre-Law"]);
+  });
+
+  test('handles empty array', () => {
+    const { broadCategories, subcategories } = splitUserInterests([]);
+    expect(broadCategories).toEqual([]);
+    expect(subcategories).toEqual([]);
+  });
+
+  test('handles all broad categories', () => {
+    const input = [
+      "Academic & Pre-Professional",
+      "Cultural & Identity-Based",
+      "Community & Advocacy",
+      "Arts & Media",
+      "Health & Wellness",
+      "Spiritual & Religious",
+      "Campus Life & Social",
+    ];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toHaveLength(7);
+    expect(subcategories).toHaveLength(0);
+  });
+
+  test('handles all subcategories (nothing matching broad categories)', () => {
+    const input = ["Pre-Law", "Dance", "Jewish"];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toHaveLength(0);
+    expect(subcategories).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails because the file doesn't exist**
+
+```bash
+npx jest src/app/profile/components/PreferencesSection.test.js --no-coverage
+```
+Expected: FAIL — `Cannot find module './PreferencesSection'`
+
+- [ ] **Step 3: Create PreferencesSection.js**
+
+First, create the directory:
+```bash
+mkdir -p src/app/profile/components
+```
+
+Then create `src/app/profile/components/PreferencesSection.js`:
+
+```js
+"use client";
+
+import { useRef, useState } from "react";
+import MultiSelectSearch from "../../onboarding/components/MultiSelectSearch";
+import MAJORS from "../../onboarding/data/majors.json";
+import MINORS from "../../onboarding/data/minors.json";
+import INTERESTS from "../../onboarding/data/interests.json";
+import Button from "../../components/button";
+
+const BROAD_CATEGORIES = Object.keys(INTERESTS);
+
+/**
+ * Splits a flat user_interests array (as returned by GET /api/profile)
+ * into broad categories and subcategories.
+ *
+ * Broad categories are the 7 top-level keys in interests.json.
+ * Everything else is treated as a subcategory.
+ */
+export function splitUserInterests(interests) {
+  const broad = interests.filter((i) => BROAD_CATEGORIES.includes(i));
+  const sub = interests.filter((i) => !BROAD_CATEGORIES.includes(i));
+  return { broadCategories: broad, subcategories: sub };
+}
+
+export default function PreferencesSection({
+  majors: initialMajors = [],
+  minors: initialMinors = [],
+  currentClubs: initialClubs = [],
+  userInterests = [],
+}) {
+  const { broadCategories: initialBroad, subcategories: initialSub } =
+    splitUserInterests(userInterests);
+
+  const [majors, setMajors] = useState(initialMajors);
+  const [minors, setMinors] = useState(initialMinors);
+  const [clubs, setClubs] = useState(initialClubs);
+  const [broadCategories, setBroadCategories] = useState(initialBroad);
+  const [subcategories, setSubcategories] = useState(initialSub);
+  const [clubOptions, setClubOptions] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState(null); // "success" | "error" | null
+  const debounceRef = useRef(null);
+
+  const handleClubQuery = (query) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setClubOptions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/clubs?name=${encodeURIComponent(query)}&page=1&sort=alphabetical`
+        );
+        const data = await res.json();
+        setClubOptions((data.orgList || []).map((c) => c.OrganizationName));
+      } catch {
+        setClubOptions([]);
+      }
+    }, 300);
+  };
+
+  const toggleCategory = (category) => {
+    const updated = broadCategories.includes(category)
+      ? broadCategories.filter((c) => c !== category)
+      : [...broadCategories, category];
+    setBroadCategories(updated);
+    // Drop any subcategories that no longer belong to a selected category
+    const validSubs = updated.flatMap((cat) => INTERESTS[cat] ?? []);
+    setSubcategories((prev) => prev.filter((s) => validSubs.includes(s)));
+  };
+
+  const toggleSubcategory = (sub) => {
+    setSubcategories((prev) =>
+      prev.includes(sub) ? prev.filter((s) => s !== sub) : [...prev, sub]
+    );
+  };
+
+  const canSave = majors.length >= 1 && broadCategories.length >= 2;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setSaveStatus(null);
+    try {
+      const res = await fetch("/api/onboarding", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          majors,
+          minors,
+          broadCategories,
+          subcategories,
+          currentClubs: clubs,
+        }),
+      });
+      if (res.ok) {
+        setSaveStatus("success");
+        setTimeout(() => setSaveStatus(null), 3000);
+      } else {
+        setSaveStatus("error");
+      }
+    } catch {
+      setSaveStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-8">
+      <div className="mb-8 text-center">
+        <p className="mb-4 text-4xl font-bold text-[#000000]">Preferences</p>
+        <p className="text-[20px] text-[#747474]">
+          Update your academic info and interests.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-10">
+        {/* Academic */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-gray-800">Academic</h2>
+          <div className="grid grid-cols-2 gap-8">
+            <MultiSelectSearch
+              label="Major(s)"
+              placeholder="Search majors..."
+              options={MAJORS}
+              selected={majors}
+              onSelect={(m) => setMajors((prev) => [...prev, m])}
+              onRemove={(m) => setMajors((prev) => prev.filter((x) => x !== m))}
+              required
+            />
+            <MultiSelectSearch
+              label="Minor(s)"
+              placeholder="Search minors..."
+              options={MINORS}
+              selected={minors}
+              onSelect={(m) => setMinors((prev) => [...prev, m])}
+              onRemove={(m) => setMinors((prev) => prev.filter((x) => x !== m))}
+            />
+          </div>
+        </section>
+
+        {/* Current Clubs */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-gray-800">Current Clubs</h2>
+          <MultiSelectSearch
+            label="Club(s) you're in"
+            placeholder="Search clubs..."
+            options={clubOptions}
+            selected={clubs}
+            onSelect={(c) => setClubs((prev) => [...prev, c])}
+            onRemove={(c) => setClubs((prev) => prev.filter((x) => x !== c))}
+            onQueryChange={handleClubQuery}
+            serverSearch
+          />
+        </section>
+
+        {/* Interest Categories */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-gray-800">
+            Interest Categories
+          </h2>
+          <p className="mb-4 text-sm text-gray-500">Select at least 2.</p>
+          <div className="grid grid-cols-8 gap-3">
+            {BROAD_CATEGORIES.map((category, i) => {
+              const isSelected = broadCategories.includes(category);
+              const colSpanClass = "col-span-2";
+              const colStartClass =
+                i === 4
+                  ? "col-start-2"
+                  : i === 5
+                  ? "col-start-4"
+                  : i === 6
+                  ? "col-start-6"
+                  : "";
+              return (
+                <button
+                  key={category}
+                  onClick={() => toggleCategory(category)}
+                  className={`
+                    ${colSpanClass} ${colStartClass}
+                    flex h-28 flex-col items-center justify-center gap-2 rounded-xl p-1
+                    text-center text-xs font-medium text-gray-900
+                    ${
+                      isSelected
+                        ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                        : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                    }
+                  `}
+                >
+                  <div className="h-8 w-8 shrink-0 rounded-full bg-gray-300" />
+                  {category}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Interest Subcategories */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-gray-800">
+            Interest Subcategories
+          </h2>
+          <p className="mb-4 text-sm text-gray-500">
+            Optional — dive deeper into your interests.
+          </p>
+          {broadCategories.length === 0 ? (
+            <p className="text-sm text-gray-400">
+              Select interest categories above to see subcategories.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-6">
+              {broadCategories.map((category) => (
+                <div key={category}>
+                  <h3 className="mb-2 text-sm font-semibold text-gray-600">
+                    {category}
+                  </h3>
+                  <div className="flex flex-wrap gap-2">
+                    {(INTERESTS[category] ?? []).map((sub) => {
+                      const isSelected = subcategories.includes(sub);
+                      return (
+                        <button
+                          key={sub}
+                          onClick={() => toggleSubcategory(sub)}
+                          className={`rounded-full px-4 py-2 text-sm font-medium ${
+                            isSelected
+                              ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                              : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                          }`}
+                        >
+                          {sub}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Save */}
+        <div className="flex flex-col gap-2 pb-8">
+          {!canSave && (
+            <p className="text-sm text-[#747474]">
+              {majors.length === 0
+                ? "Please select at least one major."
+                : "Please select at least 2 interest categories."}
+            </p>
+          )}
+          {saveStatus === "success" && (
+            <p className="text-sm text-green-600">Preferences saved!</p>
+          )}
+          {saveStatus === "error" && (
+            <p className="text-sm text-red-500">
+              Failed to save. Please try again.
+            </p>
+          )}
+          <Button type="CTA" onClick={handleSave} disabled={!canSave || saving}>
+            {saving ? "Saving…" : "Save Changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the splitUserInterests test — confirm it passes**
+
+```bash
+npx jest src/app/profile/components/PreferencesSection.test.js --no-coverage
+```
+Expected: PASS — 4 tests
+
+- [ ] **Step 5: Verify lint passes**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+---
+
+## Task 8: Wire up the profile page
+
+**Files:**
+- Modify: `src/app/profile/page.js`
+
+Four changes:
+1. Add a `profilePreferences` state to hold the pre-fill data for `PreferencesSection`
+2. Populate `profilePreferences` inside the existing `fetchProfileData` effect
+3. Add a collapsible "Preferences" section to the sidebar (same pattern as Reviews/Clubs)
+4. Add a `"preferences"` case to `getContentForSection`
+
+- [ ] **Step 1: Add the import and state**
+
+At the top of `src/app/profile/page.js`, add the import after the existing imports:
+
+```js
+import PreferencesSection from "./components/PreferencesSection";
+```
+
+Inside `ProfilePage`, add two new state variables alongside the existing ones (after `const [unreadRejectedCount, setUnreadRejectedCount] = useState(0);`):
+
+```js
+const [preferencesExpanded, setPreferencesExpanded] = useState(false);
+const [profilePreferences, setProfilePreferences] = useState(null);
+```
+
+- [ ] **Step 2: Populate profilePreferences in fetchProfileData**
+
+Inside the `if (response.ok)` block in `fetchProfileData`, after the line `setUnreadRejectedCount(data.unreadRejectedCount || 0);`, add:
+
+```js
+                    setProfilePreferences({
+                        majors: data.profile?.majors || [],
+                        minors: data.profile?.minors || [],
+                        currentClubs: data.profile?.current_clubs || [],
+                        userInterests: data.userInterests || [],
+                    });
+```
+
+- [ ] **Step 3: Add the Preferences sidebar section**
+
+In the sidebar JSX, after the closing `</div>` of the Clubs section (around line 587), add:
+
+```jsx
+                        {/* Preferences Section */}
+                        <div className="mt-4">
+                            <button
+                                onClick={() => setPreferencesExpanded(!preferencesExpanded)}
+                                className="mb-2 flex w-full items-center justify-between text-left font-semibold"
+                            >
+                                <div className="flex items-center gap-2">
+                                    <img
+                                        src="/profile_club.svg"
+                                        alt="preferences icon"
+                                        className="max-w-[20px]"
+                                    />
+                                    <span className="text-2xl">Preferences</span>
+                                </div>
+                                <svg
+                                    className={`h-4 w-4 transition-transform ${preferencesExpanded ? "rotate-180" : ""}`}
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M19 9l-7 7-7-7"
+                                    />
+                                </svg>
+                            </button>
+
+                            {preferencesExpanded && (
+                                <div className="relative ml-2 space-y-1">
+                                    <div className="absolute top-0 bottom-0 left-0 w-px bg-gray-300"></div>
+                                    <button
+                                        onClick={() => setActiveSection("preferences")}
+                                        className={`ml-3 block w-full text-left text-[#6E808D] font-medium py-2 px-3 rounded-full relative ${activeSection === "preferences" ? "bg-[#F0F2F9]" : "hover:bg-[#F0F2F9]"}`}
+                                    >
+                                        Edit Preferences
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+```
+
+- [ ] **Step 4: Add the preferences case to getContentForSection**
+
+In `getContentForSection`, add a new case before the `default` case:
+
+```js
+            case "preferences":
+                return profilePreferences ? (
+                    <PreferencesSection
+                        majors={profilePreferences.majors}
+                        minors={profilePreferences.minors}
+                        currentClubs={profilePreferences.currentClubs}
+                        userInterests={profilePreferences.userInterests}
+                    />
+                ) : (
+                    <LoadingScreen />
+                );
+```
+
+- [ ] **Step 5: Run all tests — confirm everything still passes**
+
+```bash
+npm test --no-coverage
+```
+Expected: PASS — all existing tests plus the 7 new ones (3 in interests.test.js, 4 in PreferencesSection.test.js)
+
+- [ ] **Step 6: Verify lint**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+- [ ] **Step 7: Start the dev server and manually verify the feature**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000/profile` while signed in. Check:
+- "Preferences" section appears in the sidebar and expands/collapses
+- Clicking "Edit Preferences" loads the form in the main content area
+- Majors/minors pre-fill from the user's saved data
+- Current clubs pre-fill and live search returns real club names
+- Interest category tiles match the onboarding UI (7 tiles, blue ring when selected)
+- Subcategory pills appear only under selected categories and auto-clear when a category is deselected
+- Save button is disabled with a hint message when < 1 major or < 2 categories are selected
+- Save button fires the PATCH, shows "Saving…", then shows "Preferences saved!" for 3 seconds
+- Navigate to `/onboarding` (while not yet complete) and verify the Interests step now shows real subcategory pills grouped by selected categories
+- Verify `Clubs.js` onboarding step now searches real clubs by name

--- a/docs/superpowers/specs/2026-04-12-profile-preferences-design.md
+++ b/docs/superpowers/specs/2026-04-12-profile-preferences-design.md
@@ -1,0 +1,167 @@
+# Profile Preferences Editor — Design Spec
+
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Problem
+
+Once a user exits the onboarding flow, they have no way to update the preferences they set (majors, minors, current clubs, interest categories, interest subcategories). The onboarding copy already tells users they can do this from their profile page, but the feature does not exist.
+
+## Solution
+
+Add a "Preferences" section to the profile page sidebar that renders an editable form in the main content area. The form mirrors the onboarding steps exactly and pre-fills from the user's current saved preferences.
+
+---
+
+## Architecture & Data Flow
+
+### API Changes
+
+**`GET /api/profile`** — Extend the response to include `user_interests` rows for the authenticated user, returned as a flat array of category strings (e.g. `["Arts & Media", "Dance"]`). These pre-fill both the broad categories and subcategories fields in the form.
+
+**`PATCH /api/onboarding`** — New handler alongside the existing `GET` and `POST`. Accepts the same body shape as `POST`:
+```json
+{
+  "majors": [],
+  "minors": [],
+  "broadCategories": [],
+  "subcategories": [],
+  "currentClubs": []
+}
+```
+Writes `majors`, `minors`, `current_clubs` to the `profiles` table and replaces all rows in `user_interests` for the user. Does **not** touch `onboarding_completed`. Uses `createAuthenticatedClient` for auth verification and `supabaseServer` for writes, matching the existing pattern in that route.
+
+### Clubs Search Fix
+
+`src/app/onboarding/steps/Clubs.js` currently uses a hardcoded `TEMP_CLUBS` array of 4 entries. Replace with a live debounced search against `GET /api/clubs?name=<query>` (300ms debounce), extracting `OrganizationName` strings from results. The profile preferences form uses the same approach.
+
+### Data File
+
+Create `src/app/onboarding/data/interests.json` — a JSON object mapping each of the 7 broad categories to an array of subcategory strings. Both the onboarding `Interests.js` step and the profile `PreferencesSection` import from this single source.
+
+---
+
+## Subcategory Data (`interests.json`)
+
+```json
+{
+  "Academic & Pre-Professional": [
+    "Pre-Law", "Pre-Med / Pre-Health", "Business & Finance",
+    "Engineering & Computer Science", "Research & Science",
+    "Education & Tutoring", "Consulting"
+  ],
+  "Cultural & Identity-Based": [
+    "Asian & Pacific Islander", "Black & African American",
+    "Latin & Hispanic", "Middle Eastern & North African",
+    "South Asian", "LGBTQ+", "Women & Gender"
+  ],
+  "Community & Advocacy": [
+    "Environmental & Sustainability", "Social Justice",
+    "Volunteering & Service", "Political & Civic Engagement",
+    "Mental Health Awareness", "Housing & Food Security"
+  ],
+  "Arts & Media": [
+    "Visual Arts & Design", "Music & Performance",
+    "Film & Photography", "Journalism & Writing",
+    "Dance", "Theater & Acting"
+  ],
+  "Health & Wellness": [
+    "Fitness & Sports", "Martial Arts",
+    "Outdoors & Adventure", "Mental Health",
+    "Nutrition & Cooking"
+  ],
+  "Spiritual & Religious": [
+    "Christian", "Jewish", "Muslim",
+    "Hindu & Buddhist", "Interfaith & Secular"
+  ],
+  "Campus Life & Social": [
+    "Greek Life", "Gaming & Esports",
+    "Hobby & Interest Groups", "Leadership & Student Government",
+    "Networking & Professional", "Cultural Events"
+  ]
+}
+```
+
+---
+
+## UI Components
+
+### Sidebar
+
+Add a third collapsible section "Preferences" to the profile sidebar, below "Clubs". Follows the exact same expand/collapse pattern as "Reviews" and "Clubs" (chevron icon, toggle state). Contains a single sub-item that sets `activeSection` to `"preferences"`.
+
+### `PreferencesSection` (`src/app/profile/components/PreferencesSection.js`)
+
+A scrollable form rendered in the main content area when `activeSection === "preferences"`. Four labeled sections:
+
+1. **Academic**
+   - Two `MultiSelectSearch` components side-by-side (same layout as `Majors.js`)
+   - Imports `majors.json` and `minors.json` from `src/app/onboarding/data/`
+   - Majors field is required (at least 1)
+
+2. **Current Clubs**
+   - Single `MultiSelectSearch` with live search
+   - Fetches from `GET /api/clubs?name=<query>`, debounced 300ms
+   - Displays `OrganizationName` strings as options
+
+3. **Interest Categories**
+   - Exact same 7-button toggle grid as `Categories.js`
+   - Minimum 2 required to save
+   - Selecting/deselecting a category reactively shows/hides its subcategories in section 4
+
+4. **Interest Subcategories**
+   - Same visual style as categories grid (rounded tiles, selected = blue ring)
+   - Only shows subcategories belonging to the user's currently-selected broad categories
+   - If no broad categories are selected: shows a muted prompt — "Select interest categories above to see subcategories"
+   - Optional — no minimum
+
+**Save button:** `Button` with `type="CTA"`, label "Save Changes". Disabled when validation fails (missing major or fewer than 2 categories) or while save is in flight (label becomes "Saving…"). On success: inline green message "Preferences saved!" auto-dismisses after 3s. On error: inline red error message persists until next save attempt.
+
+**Pre-fill:** On mount, `PreferencesSection` receives the following props from the parent profile page (no additional fetch needed):
+- `majors` — from `data.profile.majors`
+- `minors` — from `data.profile.minors`
+- `currentClubs` — from `data.profile.current_clubs`
+- `userInterests` — from `data.userInterests` (the new flat array added to the profile API response)
+
+`userInterests` is split into broad categories (strings matching any of the 7 known category names from `Categories.js`) and subcategories (everything else).
+
+**Imports:** `PreferencesSection` imports `MultiSelectSearch` from `src/app/onboarding/components/MultiSelectSearch.js`, `majors.json` and `minors.json` from `src/app/onboarding/data/`, and `interests.json` from `src/app/onboarding/data/`.
+
+---
+
+## Finishing `Interests.js`
+
+`src/app/onboarding/steps/Interests.js` is currently placeholder code. Replace with:
+- Import `interests.json`
+- Filter visible subcategories to those under the selected broad categories from `formData.interests` (passed down from parent `formData`)
+- Same tile toggle UI as `Categories.js`
+- Optional — `onValidChange(true)` always (no minimum for onboarding either, matching the existing `canAdvance` default)
+- On toggle, call `onUpdate({ subcategories: updated })`
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|---|---|
+| Majors | At least 1 required |
+| Minors | Optional |
+| Current Clubs | Optional |
+| Interest Categories | At least 2 required |
+| Interest Subcategories | Optional |
+
+These rules apply identically in both the onboarding flow and the profile preferences form.
+
+---
+
+## Files Changed / Created
+
+| File | Change |
+|---|---|
+| `src/app/api/profile/route.js` | Add `user_interests` to GET response |
+| `src/app/api/onboarding/route.js` | Add PATCH handler |
+| `src/app/onboarding/steps/Clubs.js` | Replace TEMP_CLUBS with live `/api/clubs` search |
+| `src/app/onboarding/steps/Interests.js` | Finish implementation using `interests.json` |
+| `src/app/onboarding/data/interests.json` | Create subcategory data file |
+| `src/app/profile/page.js` | Add Preferences sidebar section; pass profile data to PreferencesSection |
+| `src/app/profile/components/PreferencesSection.js` | Create preferences editing form |

--- a/src/app/api/onboarding/route.js
+++ b/src/app/api/onboarding/route.js
@@ -82,3 +82,61 @@ export async function POST(req) {
     return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 }
+
+// PATCH /api/onboarding
+// Updates user preferences without changing onboarding_completed.
+// Body: { majors, minors, broadCategories, subcategories, currentClubs }
+export async function PATCH(req) {
+  try {
+    const supabase = await createAuthenticatedClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { majors = [], minors = [], broadCategories = [], subcategories = [], currentClubs = [] } = await req.json();
+
+    const { error: profileError } = await supabaseServer
+      .from("profiles")
+      .update({
+        majors,
+        minors,
+        current_clubs: currentClubs,
+      })
+      .eq("id", user.id);
+
+    if (profileError) {
+      return Response.json({ error: "Failed to save profile preferences" }, { status: 500 });
+    }
+
+    // Always delete existing interests first, then re-insert if any selected.
+    const { error: deleteError } = await supabaseServer
+      .from("user_interests")
+      .delete()
+      .eq("user_id", user.id);
+
+    if (deleteError) {
+      return Response.json({ error: "Failed to clear interest preferences" }, { status: 500 });
+    }
+
+    // Note: delete and insert are not atomic. If the insert fails after the delete
+    // has committed, the user's interests will be empty until they save again.
+    // A Supabase RPC (database function) would be needed for true atomicity.
+    const allInterests = [...new Set([...broadCategories, ...subcategories])];
+
+    if (allInterests.length > 0) {
+      const { error: interestsError } = await supabaseServer
+        .from("user_interests")
+        .insert(allInterests.map((category) => ({ user_id: user.id, category })));
+
+      if (interestsError) {
+        return Response.json({ error: "Failed to save interest preferences" }, { status: 500 });
+      }
+    }
+
+    return Response.json({ success: true });
+  } catch {
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/profile/route.js
+++ b/src/app/api/profile/route.js
@@ -85,6 +85,16 @@ export async function GET(req) {
       console.error('Error fetching saved clubs:', savedClubsError);
     }
 
+    // Fetch user interests
+    const { data: userInterestsData, error: interestsError } = await supabase
+      .from('user_interests')
+      .select('category')
+      .eq('user_id', userId);
+
+    if (interestsError) {
+      console.error('Error fetching user interests:', interestsError);
+    }
+
     // Transform liked clubs data to match the format in the original code
     const likedClubs = likedClubsData ? likedClubsData.map(item => item.clubs) : [];
     const savedClubs = savedClubsData ? savedClubsData.map(item => item.clubs) : [];
@@ -143,6 +153,7 @@ export async function GET(req) {
         likedClubs: likedClubsWithCounts,
         savedClubs: savedClubsWithCounts,
         unreadRejectedCount,
+        userInterests: (userInterestsData || []).map((row) => row.category),
       }),
       { status: 200 }
     );

--- a/src/app/onboarding/components/MultiSelectSearch.js
+++ b/src/app/onboarding/components/MultiSelectSearch.js
@@ -11,24 +11,29 @@ export default function MultiSelectSearch({
   onSelect,
   onRemove,
   required = false,
+  onQueryChange,   // optional: called with the raw query string on every keystroke
+  serverSearch = false, // when true, skip client-side filtering (parent provides pre-filtered options)
 }) {
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef(null);
 
   const lowerQuery = query.toLowerCase();
-  const filtered = query.trim() === ""
-    ? []
-    : options
-        .filter((o) => !selected.includes(o))
-        .filter((o) => o.toLowerCase().includes(lowerQuery))
-        .sort((a, b) => {
-          const indexA = a.toLowerCase().indexOf(lowerQuery);
-          const indexB = b.toLowerCase().indexOf(lowerQuery);
-          if (indexA !== indexB) return indexA - indexB;
-          return a.toLowerCase().localeCompare(b.toLowerCase());
-        })
-        .slice(0, 8);
+
+  const filtered = serverSearch
+    ? options.filter((o) => !selected.includes(o)).slice(0, 8)
+    : query.trim() === ""
+      ? []
+      : options
+          .filter((o) => !selected.includes(o))
+          .filter((o) => o.toLowerCase().includes(lowerQuery))
+          .sort((a, b) => {
+            const indexA = a.toLowerCase().indexOf(lowerQuery);
+            const indexB = b.toLowerCase().indexOf(lowerQuery);
+            if (indexA !== indexB) return indexA - indexB;
+            return a.toLowerCase().localeCompare(b.toLowerCase());
+          })
+          .slice(0, 8);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -43,6 +48,7 @@ export default function MultiSelectSearch({
   const handleSelect = (option) => {
     onSelect(option);
     setQuery("");
+    if (onQueryChange) onQueryChange("");
     setIsOpen(false);
   };
 
@@ -57,7 +63,11 @@ export default function MultiSelectSearch({
         <input
           type="text"
           value={query}
-          onChange={(e) => { setQuery(e.target.value); setIsOpen(true); }}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+            if (onQueryChange) onQueryChange(e.target.value);
+          }}
           onFocus={() => setIsOpen(true)}
           placeholder={placeholder}
           className="w-full rounded-full bg-[#F4F5F6] py-3 pl-5 pr-12 text-sm text-gray-700 hover:bg-[#E5EBF1] focus:bg-[#E5EBF1] focus:outline-none"
@@ -83,7 +93,7 @@ export default function MultiSelectSearch({
           </ul>
         )}
 
-        {isOpen && query.trim() && filtered.length === 0 && (
+        {isOpen && filtered.length === 0 && (query.trim() || serverSearch) && (
           <div className="absolute z-10 mt-1 w-full rounded-xl bg-white px-4 py-3 text-sm text-gray-500 shadow-lg">
             No results for &quot;{query}&quot;
           </div>
@@ -99,7 +109,7 @@ export default function MultiSelectSearch({
             >
               {item}
               <button
-                onClick={() => onRemove(item)}
+                onClick={() => { onRemove(item); if (onQueryChange) onQueryChange(""); }}
                 className="ml-0.5 text-gray-500 hover:text-gray-700"
                 aria-label={`Remove ${item}`}
               >

--- a/src/app/onboarding/components/MultiSelectSearch.js
+++ b/src/app/onboarding/components/MultiSelectSearch.js
@@ -20,20 +20,23 @@ export default function MultiSelectSearch({
 
   const lowerQuery = query.toLowerCase();
 
+  const sortByMatchIndex = (list) =>
+    list.sort((a, b) => {
+      const indexA = a.toLowerCase().indexOf(lowerQuery);
+      const indexB = b.toLowerCase().indexOf(lowerQuery);
+      if (indexA !== indexB) return indexA - indexB;
+      return a.toLowerCase().localeCompare(b.toLowerCase());
+    });
+
   const filtered = serverSearch
-    ? options.filter((o) => !selected.includes(o)).slice(0, 8)
+    ? sortByMatchIndex(options.filter((o) => !selected.includes(o))).slice(0, 8)
     : query.trim() === ""
       ? []
-      : options
-          .filter((o) => !selected.includes(o))
-          .filter((o) => o.toLowerCase().includes(lowerQuery))
-          .sort((a, b) => {
-            const indexA = a.toLowerCase().indexOf(lowerQuery);
-            const indexB = b.toLowerCase().indexOf(lowerQuery);
-            if (indexA !== indexB) return indexA - indexB;
-            return a.toLowerCase().localeCompare(b.toLowerCase());
-          })
-          .slice(0, 8);
+      : sortByMatchIndex(
+          options
+            .filter((o) => !selected.includes(o))
+            .filter((o) => o.toLowerCase().includes(lowerQuery))
+        ).slice(0, 8);
 
   useEffect(() => {
     const handleClickOutside = (e) => {

--- a/src/app/onboarding/data/interests.json
+++ b/src/app/onboarding/data/interests.json
@@ -1,0 +1,58 @@
+{
+  "Academic & Pre-Professional": [
+    "Pre-Law",
+    "Pre-Med / Pre-Health",
+    "Business & Finance",
+    "Engineering & Computer Science",
+    "Research & Science",
+    "Education & Tutoring",
+    "Consulting"
+  ],
+  "Cultural & Identity-Based": [
+    "Asian & Pacific Islander",
+    "Black & African American",
+    "Latin & Hispanic",
+    "Middle Eastern & North African",
+    "South Asian",
+    "LGBTQ+",
+    "Women & Gender"
+  ],
+  "Community & Advocacy": [
+    "Environmental & Sustainability",
+    "Social Justice",
+    "Volunteering & Service",
+    "Political & Civic Engagement",
+    "Mental Health Awareness",
+    "Housing & Food Security"
+  ],
+  "Arts & Media": [
+    "Visual Arts & Design",
+    "Music & Performance",
+    "Film & Photography",
+    "Journalism & Writing",
+    "Dance",
+    "Theater & Acting"
+  ],
+  "Health & Wellness": [
+    "Fitness & Sports",
+    "Martial Arts",
+    "Outdoors & Adventure",
+    "Mental Health",
+    "Nutrition & Cooking"
+  ],
+  "Spiritual & Religious": [
+    "Christian",
+    "Jewish",
+    "Muslim",
+    "Hindu & Buddhist",
+    "Interfaith & Secular"
+  ],
+  "Campus Life & Social": [
+    "Greek Life",
+    "Gaming & Esports",
+    "Hobby & Interest Groups",
+    "Leadership & Student Government",
+    "Networking & Professional",
+    "Cultural Events"
+  ]
+}

--- a/src/app/onboarding/data/interests.test.js
+++ b/src/app/onboarding/data/interests.test.js
@@ -1,0 +1,43 @@
+/**
+ * Structural tests for interests.json.
+ *
+ * interests.json is the subcategory data for the onboarding Interests step
+ * (src/app/onboarding/steps/Interests.js) and the profile PreferencesSection
+ * (src/app/profile/components/PreferencesSection.js). Both components import
+ * this file directly.
+ */
+import INTERESTS from './interests.json';
+
+// Must stay in sync with the top-level keys of interests.json
+const BROAD_CATEGORIES = [
+  "Academic & Pre-Professional",
+  "Cultural & Identity-Based",
+  "Community & Advocacy",
+  "Arts & Media",
+  "Health & Wellness",
+  "Spiritual & Religious",
+  "Campus Life & Social",
+];
+
+describe('interests.json', () => {
+  test('has exactly the 7 expected broad categories', () => {
+    expect(Object.keys(INTERESTS)).toHaveLength(7);
+    BROAD_CATEGORIES.forEach(cat => {
+      expect(INTERESTS).toHaveProperty(cat);
+    });
+  });
+
+  test('each category has at least 3 subcategories', () => {
+    BROAD_CATEGORIES.forEach(cat => {
+      expect(Array.isArray(INTERESTS[cat])).toBe(true);
+      expect(INTERESTS[cat].length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  test('all subcategories are non-empty strings', () => {
+    Object.values(INTERESTS).flat().forEach(sub => {
+      expect(typeof sub).toBe('string');
+      expect(sub.trim().length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/app/onboarding/steps/Clubs.js
+++ b/src/app/onboarding/steps/Clubs.js
@@ -1,24 +1,43 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import MultiSelectSearch from "../components/MultiSelectSearch";
-
-const TEMP_CLUBS = [
-  "ACM",
-  "Clubhouse",
-  "Refine LA",
-  "CCDC",
-];
 
 export default function Clubs({ formData, onUpdate, onValidChange }) {
   const [selectedClubs, setSelectedClubs] = useState(formData.clubs ?? []);
+  const [clubOptions, setClubOptions] = useState([]);
+  const debounceRef = useRef(null);
 
-  // mmm still working on the design for this... will ask Nancy about it !!
   useEffect(() => {
-    onValidChange(true);
+    onValidChange(true); // optional step
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleQueryChange = (query) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setClubOptions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/clubs?name=${encodeURIComponent(query)}&page=1&sort=alphabetical`
+        );
+        if (!res.ok) { setClubOptions([]); return; }
+        const data = await res.json();
+        setClubOptions((data.orgList || []).map((c) => c.OrganizationName));
+      } catch {
+        setClubOptions([]);
+      }
+    }, 300);
+  };
+
   const handleSelect = (club) => {
+    if (selectedClubs.includes(club)) return;
     const updated = [...selectedClubs, club];
     setSelectedClubs(updated);
     onUpdate({ clubs: updated });
@@ -31,8 +50,7 @@ export default function Clubs({ formData, onUpdate, onValidChange }) {
   };
 
   return (
-    <>
-      <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-8">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Which clubs are you in?</h1>
         <p className="mt-1 text-sm text-gray-500">
@@ -43,24 +61,22 @@ export default function Clubs({ formData, onUpdate, onValidChange }) {
         </p>
       </div>
 
-        {/* place holder search bar :3 */}
       <MultiSelectSearch
         label="Select your club(s)"
         placeholder="Search clubs..."
-        options={TEMP_CLUBS}
+        options={clubOptions}
         selected={selectedClubs}
         onSelect={handleSelect}
         onRemove={handleRemove}
+        onQueryChange={handleQueryChange}
+        serverSearch
       />
 
       {selectedClubs.length === 0 && (
-        <p className="-mt-4 text-xs text-black-400">
+        <p className="-mt-4 text-xs text-gray-400">
           Not in any clubs yet? You can skip this step.
         </p>
       )}
     </div>
-
-    </>
-    
   );
 }

--- a/src/app/onboarding/steps/Interests.js
+++ b/src/app/onboarding/steps/Interests.js
@@ -1,143 +1,77 @@
 "use client";
 
-import Button from "../../components/button"
 import { useEffect, useState } from "react";
+import INTERESTS from "../data/interests.json";
 
-export default function Interests({formData, onUpdate, onValidChange}) {
+export default function Interests({ formData, onUpdate, onValidChange }) {
+  const [selected, setSelected] = useState(formData.subcategories ?? []);
+  const selectedCategories = formData.interests ?? [];
 
-    const exampleCategories = ["Arts", "Dance", "Film", "Theater", "Poetry", "Somethingg"];
+  useEffect(() => {
+    onValidChange(true); // optional step — always allow advancing
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    const [clicked, setClicked] = useState(0);
-
-    const isClicked = false;
-
-    useEffect(()=> {
-        // onValidChange(clicked>=2);
-
-    }, [clicked])
-    const select = (interest) => {  
-
+  // Prune subcategory selections that no longer belong to any selected broad category
+  // (handles the case where a user goes back and deselects a category)
+  useEffect(() => {
+    const validSubs = selectedCategories.flatMap((cat) => INTERESTS[cat] ?? []);
+    const pruned = selected.filter((s) => validSubs.includes(s));
+    if (pruned.length !== selected.length) {
+      setSelected(pruned);
+      onUpdate({ subcategories: pruned });
     }
-    return (
-        <>
-            <div className="ml-15">
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCategories.join(",")]);
 
+  const toggle = (subcategory) => {
+    const updated = selected.includes(subcategory)
+      ? selected.filter((s) => s !== subcategory)
+      : [...selected, subcategory];
+    setSelected(updated);
+    onUpdate({ subcategories: updated });
+  };
 
-                <h1 className="text-2xl font-bold text-[#1C350F]">Choose Your Interest</h1>
-                <p className="text-[0.8rem] mt-1 text-black">
-                    We'll be using this information to personalize club recommendations for you. 
-                    Please select at least 2 categories to continue.</p>
-                <h1 className="text-2xl mt-15 font-bold text-[#1C350F]">Main Category 1</h1>
-                <div className="flex flex-wrap gap-2 mt-3">
-                    {exampleCategories.map((interest) => (
-                        <Button
-                            key={interest}
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                            isSelected={isClicked}
-                            onClick={()=> {}}
-                        >
-                            {interest}
-                        </Button>
-                    ))}
-                    <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            somethingg
-                        </Button>
-                        <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            something
-                        </Button>
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Dive deeper into your interests!</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Select any specific areas you&apos;re interested in. This step is optional.
+        </p>
+      </div>
 
-                    {exampleCategories.map((interest) => (
-                        <Button
-                            key={interest}
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            {interest}
-                        </Button>
-                    ))}
-                    <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            somethingg
-                        </Button>
-                        <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            something
-                        </Button>
-
-                </div>
-
-                <h1 className="text-2xl mt-5 font-bold text-[#1C350F]">Main Category 1</h1>
-                <div className="flex flex-wrap gap-2 mt-3 ">
-                    {exampleCategories.map((interest) => (
-                        <Button
-                            key={interest}
-                            type="tag"
-                            size="small"
-                            style=""
-                            onClick={select(interest)}
-                            // className="drop-shadow-xs py-2 px-4 text-sm"
-                        >
-                            {interest}
-                        </Button>
-                    ))}
-                    <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            somethingg
-                        </Button>
-                        <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            something
-                        </Button>
-                    {exampleCategories.map((interest) => (
-                        <Button
-                            key={interest}
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            {interest}
-                        </Button>
-                    ))}
-                    <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            somethingg
-                        </Button>
-                        <Button
-                            type="tag"
-                            size="small"
-                            style="drop-shadow-xs"
-                        >
-                            something
-                        </Button>
-
-                </div>
+      {selectedCategories.length === 0 ? (
+        <p className="text-sm text-gray-400">
+          Go back and select interest categories to see subcategories here.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {selectedCategories.map((category) => (
+            <div key={category}>
+              <h2 className="mb-2 text-sm font-semibold text-gray-600">{category}</h2>
+              <div className="flex flex-wrap gap-2">
+                {(INTERESTS[category] ?? []).map((sub) => {
+                  const isSelected = selected.includes(sub);
+                  return (
+                    <button
+                      key={sub}
+                      onClick={() => toggle(sub)}
+                      className={`rounded-full px-4 py-2 text-sm font-medium ${
+                        isSelected
+                          ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                          : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                      }`}
+                    >
+                      {sub}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-        </>
-    )
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/app/onboarding/steps/Interests.js
+++ b/src/app/onboarding/steps/Interests.js
@@ -1,77 +1,143 @@
 "use client";
 
+import Button from "../../components/button"
 import { useEffect, useState } from "react";
-import INTERESTS from "../data/interests.json";
 
-export default function Interests({ formData, onUpdate, onValidChange }) {
-  const [selected, setSelected] = useState(formData.subcategories ?? []);
-  const selectedCategories = formData.interests ?? [];
+export default function Interests({formData, onUpdate, onValidChange}) {
 
-  useEffect(() => {
-    onValidChange(true); // optional step — always allow advancing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const exampleCategories = ["Arts", "Dance", "Film", "Theater", "Poetry", "Somethingg"];
 
-  // Prune subcategory selections that no longer belong to any selected broad category
-  // (handles the case where a user goes back and deselects a category)
-  useEffect(() => {
-    const validSubs = selectedCategories.flatMap((cat) => INTERESTS[cat] ?? []);
-    const pruned = selected.filter((s) => validSubs.includes(s));
-    if (pruned.length !== selected.length) {
-      setSelected(pruned);
-      onUpdate({ subcategories: pruned });
+    const [clicked, setClicked] = useState(0);
+
+    const isClicked = false;
+
+    useEffect(()=> {
+        // onValidChange(clicked>=2);
+
+    }, [clicked])
+    const select = (interest) => {
+
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCategories.join(",")]);
+    return (
+        <>
+            <div className="ml-15">
 
-  const toggle = (subcategory) => {
-    const updated = selected.includes(subcategory)
-      ? selected.filter((s) => s !== subcategory)
-      : [...selected, subcategory];
-    setSelected(updated);
-    onUpdate({ subcategories: updated });
-  };
 
-  return (
-    <div className="flex flex-col gap-8">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dive deeper into your interests!</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Select any specific areas you&apos;re interested in. This step is optional.
-        </p>
-      </div>
+                <h1 className="text-2xl font-bold text-[#1C350F]">Choose Your Interest</h1>
+                <p className="text-[0.8rem] mt-1 text-black">
+                    We'll be using this information to personalize club recommendations for you.
+                    Please select at least 2 categories to continue.</p>
+                <h1 className="text-2xl mt-15 font-bold text-[#1C350F]">Main Category 1</h1>
+                <div className="flex flex-wrap gap-2 mt-3">
+                    {exampleCategories.map((interest) => (
+                        <Button
+                            key={interest}
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                            isSelected={isClicked}
+                            onClick={()=> {}}
+                        >
+                            {interest}
+                        </Button>
+                    ))}
+                    <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            somethingg
+                        </Button>
+                        <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            something
+                        </Button>
 
-      {selectedCategories.length === 0 ? (
-        <p className="text-sm text-gray-400">
-          Go back and select interest categories to see subcategories here.
-        </p>
-      ) : (
-        <div className="flex flex-col gap-6">
-          {selectedCategories.map((category) => (
-            <div key={category}>
-              <h2 className="mb-2 text-sm font-semibold text-gray-600">{category}</h2>
-              <div className="flex flex-wrap gap-2">
-                {(INTERESTS[category] ?? []).map((sub) => {
-                  const isSelected = selected.includes(sub);
-                  return (
-                    <button
-                      key={sub}
-                      onClick={() => toggle(sub)}
-                      className={`rounded-full px-4 py-2 text-sm font-medium ${
-                        isSelected
-                          ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
-                          : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
-                      }`}
-                    >
-                      {sub}
-                    </button>
-                  );
-                })}
-              </div>
+                    {exampleCategories.map((interest) => (
+                        <Button
+                            key={interest}
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            {interest}
+                        </Button>
+                    ))}
+                    <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            somethingg
+                        </Button>
+                        <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            something
+                        </Button>
+
+                </div>
+
+                <h1 className="text-2xl mt-5 font-bold text-[#1C350F]">Main Category 1</h1>
+                <div className="flex flex-wrap gap-2 mt-3 ">
+                    {exampleCategories.map((interest) => (
+                        <Button
+                            key={interest}
+                            type="tag"
+                            size="small"
+                            style=""
+                            onClick={select(interest)}
+                            // className="drop-shadow-xs py-2 px-4 text-sm"
+                        >
+                            {interest}
+                        </Button>
+                    ))}
+                    <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            somethingg
+                        </Button>
+                        <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            something
+                        </Button>
+                    {exampleCategories.map((interest) => (
+                        <Button
+                            key={interest}
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            {interest}
+                        </Button>
+                    ))}
+                    <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            somethingg
+                        </Button>
+                        <Button
+                            type="tag"
+                            size="small"
+                            style="drop-shadow-xs"
+                        >
+                            something
+                        </Button>
+
+                </div>
             </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+        </>
+    )
 }

--- a/src/app/profile/components/PreferencesSection.js
+++ b/src/app/profile/components/PreferencesSection.js
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import MultiSelectSearch from "../../onboarding/components/MultiSelectSearch";
+import MAJORS from "../../onboarding/data/majors.json";
+import MINORS from "../../onboarding/data/minors.json";
+import INTERESTS from "../../onboarding/data/interests.json";
+import Button from "../../components/button";
+
+const BROAD_CATEGORIES = Object.keys(INTERESTS);
+
+/**
+ * Splits a flat user_interests array (as returned by GET /api/profile)
+ * into broad categories and subcategories.
+ *
+ * Broad categories are the 7 top-level keys in interests.json.
+ * Everything else is treated as a subcategory.
+ */
+export function splitUserInterests(interests, broadCategories = BROAD_CATEGORIES) {
+  const broad = interests.filter((i) => broadCategories.includes(i));
+  const sub = interests.filter((i) => !broadCategories.includes(i));
+  return { broadCategories: broad, subcategories: sub };
+}
+
+export default function PreferencesSection({
+  majors: initialMajors = [],
+  minors: initialMinors = [],
+  currentClubs: initialClubs = [],
+  userInterests = [],
+}) {
+  const { broadCategories: initialBroad, subcategories: initialSub } =
+    splitUserInterests(userInterests);
+
+  const [majors, setMajors] = useState(initialMajors);
+  const [minors, setMinors] = useState(initialMinors);
+  const [clubs, setClubs] = useState(initialClubs);
+  const [broadCategories, setBroadCategories] = useState(initialBroad);
+  const [subcategories, setSubcategories] = useState(initialSub);
+  const [clubOptions, setClubOptions] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState(null); // "success" | "error" | null
+  const debounceRef = useRef(null);
+  const saveTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
+  const handleClubQuery = (query) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setClubOptions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/clubs?name=${encodeURIComponent(query)}&page=1&sort=alphabetical`
+        );
+        if (!res.ok) { setClubOptions([]); return; }
+        const data = await res.json();
+        setClubOptions((data.orgList || []).map((c) => c.OrganizationName));
+      } catch {
+        setClubOptions([]);
+      }
+    }, 300);
+  };
+
+  const toggleCategory = (category) => {
+    const updated = broadCategories.includes(category)
+      ? broadCategories.filter((c) => c !== category)
+      : [...broadCategories, category];
+    setBroadCategories(updated);
+    // Drop any subcategories that no longer belong to a selected category
+    const validSubs = updated.flatMap((cat) => INTERESTS[cat] ?? []);
+    setSubcategories((prev) => prev.filter((s) => validSubs.includes(s)));
+  };
+
+  const toggleSubcategory = (sub) => {
+    setSubcategories((prev) =>
+      prev.includes(sub) ? prev.filter((s) => s !== sub) : [...prev, sub]
+    );
+  };
+
+  const canSave = majors.length >= 1 && broadCategories.length >= 2;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setSaveStatus(null);
+    try {
+      const res = await fetch("/api/onboarding", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          majors,
+          minors,
+          broadCategories,
+          subcategories,
+          currentClubs: clubs,
+        }),
+      });
+      if (res.ok) {
+        setSaveStatus("success");
+        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = setTimeout(() => setSaveStatus(null), 3000);
+      } else {
+        setSaveStatus("error");
+      }
+    } catch {
+      setSaveStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-8">
+      <div className="mb-8 text-center">
+        <p className="mb-4 text-4xl font-bold text-[#000000]">Preferences</p>
+        <p className="text-[20px] text-[#747474]">
+          Update your academic info and interests.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-10">
+        {/* Academic */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-gray-800">Academic</h2>
+          <div className="grid grid-cols-2 gap-8">
+            <MultiSelectSearch
+              label="Major(s)"
+              placeholder="Search majors..."
+              options={MAJORS}
+              selected={majors}
+              onSelect={(m) => setMajors((prev) => [...prev, m])}
+              onRemove={(m) => setMajors((prev) => prev.filter((x) => x !== m))}
+              required
+            />
+            <MultiSelectSearch
+              label="Minor(s)"
+              placeholder="Search minors..."
+              options={MINORS}
+              selected={minors}
+              onSelect={(m) => setMinors((prev) => [...prev, m])}
+              onRemove={(m) => setMinors((prev) => prev.filter((x) => x !== m))}
+            />
+          </div>
+        </section>
+
+        {/* Current Clubs */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-gray-800">Current Clubs</h2>
+          <MultiSelectSearch
+            label="Club(s) you're in"
+            placeholder="Search clubs..."
+            options={clubOptions}
+            selected={clubs}
+            onSelect={(c) => setClubs((prev) => prev.includes(c) ? prev : [...prev, c])}
+            onRemove={(c) => setClubs((prev) => prev.filter((x) => x !== c))}
+            onQueryChange={handleClubQuery}
+            serverSearch
+          />
+        </section>
+
+        {/* Interest Categories */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-gray-800">
+            Interest Categories
+          </h2>
+          <p className="mb-4 text-sm text-gray-500">Select at least 2.</p>
+          <div className="grid grid-cols-8 gap-3">
+            {BROAD_CATEGORIES.map((category, i) => {
+              const isSelected = broadCategories.includes(category);
+              const colSpanClass = "col-span-2";
+              const colStartClass =
+                i === 4
+                  ? "col-start-2"
+                  : i === 5
+                  ? "col-start-4"
+                  : i === 6
+                  ? "col-start-6"
+                  : "";
+              return (
+                <button
+                  key={category}
+                  onClick={() => toggleCategory(category)}
+                  className={`
+                    ${colSpanClass} ${colStartClass}
+                    flex h-28 flex-col items-center justify-center gap-2 rounded-xl p-1
+                    text-center text-xs font-medium text-gray-900
+                    ${
+                      isSelected
+                        ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                        : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                    }
+                  `}
+                >
+                  <div className="h-8 w-8 shrink-0 rounded-full bg-gray-300" />
+                  {category}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Interest Subcategories */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-gray-800">
+            Interest Subcategories
+          </h2>
+          <p className="mb-4 text-sm text-gray-500">
+            Optional — dive deeper into your interests.
+          </p>
+          {broadCategories.length === 0 ? (
+            <p className="text-sm text-gray-400">
+              Select interest categories above to see subcategories.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-6">
+              {broadCategories.map((category) => (
+                <div key={category}>
+                  <h3 className="mb-2 text-sm font-semibold text-gray-600">
+                    {category}
+                  </h3>
+                  <div className="flex flex-wrap gap-2">
+                    {(INTERESTS[category] ?? []).map((sub) => {
+                      const isSelected = subcategories.includes(sub);
+                      return (
+                        <button
+                          key={sub}
+                          onClick={() => toggleSubcategory(sub)}
+                          className={`rounded-full px-4 py-2 text-sm font-medium ${
+                            isSelected
+                              ? "bg-[#D6EEFF] ring-2 ring-[#7BBFEE]"
+                              : "bg-[#F4F5F6] hover:bg-[#E5EBF1]"
+                          }`}
+                        >
+                          {sub}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Save */}
+        <div className="flex flex-col gap-2 pb-8">
+          {!canSave && (
+            <p className="text-sm text-[#747474]">
+              {majors.length === 0
+                ? "Please select at least one major."
+                : "Please select at least 2 interest categories."}
+            </p>
+          )}
+          {saveStatus === "success" && (
+            <p className="text-sm text-green-600">Preferences saved!</p>
+          )}
+          {saveStatus === "error" && (
+            <p className="text-sm text-red-500">
+              Failed to save. Please try again.
+            </p>
+          )}
+          <Button type="CTA" onClick={handleSave} disabled={!canSave || saving}>
+            {saving ? "Saving…" : "Save Changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/components/PreferencesSection.js
+++ b/src/app/profile/components/PreferencesSection.js
@@ -7,21 +7,9 @@ import MINORS from "../../onboarding/data/minors.json";
 import INTERESTS from "../../onboarding/data/interests.json";
 import Button from "../../components/button";
 import { supabase } from "../../lib/db";
+import { splitUserInterests } from "../../utils/splitUserInterests";
 
 const BROAD_CATEGORIES = Object.keys(INTERESTS);
-
-/**
- * Splits a flat user_interests array (as returned by GET /api/profile)
- * into broad categories and subcategories.
- *
- * Broad categories are the 7 top-level keys in interests.json.
- * Everything else is treated as a subcategory.
- */
-export function splitUserInterests(interests, broadCategories = BROAD_CATEGORIES) {
-  const broad = interests.filter((i) => broadCategories.includes(i));
-  const sub = interests.filter((i) => !broadCategories.includes(i));
-  return { broadCategories: broad, subcategories: sub };
-}
 
 export default function PreferencesSection({
   majors: initialMajors = [],

--- a/src/app/profile/components/PreferencesSection.js
+++ b/src/app/profile/components/PreferencesSection.js
@@ -6,6 +6,7 @@ import MAJORS from "../../onboarding/data/majors.json";
 import MINORS from "../../onboarding/data/minors.json";
 import INTERESTS from "../../onboarding/data/interests.json";
 import Button from "../../components/button";
+import { supabase } from "../../lib/db";
 
 const BROAD_CATEGORIES = Object.keys(INTERESTS);
 
@@ -39,35 +40,25 @@ export default function PreferencesSection({
   const [clubOptions, setClubOptions] = useState([]);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState(null); // "success" | "error" | null
-  const debounceRef = useRef(null);
   const saveTimerRef = useRef(null);
 
   useEffect(() => {
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
   }, []);
 
-  const handleClubQuery = (query) => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (!query.trim()) {
-      setClubOptions([]);
-      return;
-    }
-    debounceRef.current = setTimeout(async () => {
-      try {
-        const res = await fetch(
-          `/api/clubs?name=${encodeURIComponent(query)}&page=1&sort=alphabetical`
-        );
-        if (!res.ok) { setClubOptions([]); return; }
-        const data = await res.json();
-        setClubOptions((data.orgList || []).map((c) => c.OrganizationName));
-      } catch {
-        setClubOptions([]);
+  useEffect(() => {
+    const fetchClubNames = async () => {
+      const { data, error } = await supabase
+        .from("clubs")
+        .select("OrganizationName");
+      if (!error && data) {
+        setClubOptions(data.map((c) => c.OrganizationName));
       }
-    }, 300);
-  };
+    };
+    fetchClubNames();
+  }, []);
 
   const toggleCategory = (category) => {
     const updated = broadCategories.includes(category)
@@ -161,8 +152,6 @@ export default function PreferencesSection({
             selected={clubs}
             onSelect={(c) => setClubs((prev) => prev.includes(c) ? prev : [...prev, c])}
             onRemove={(c) => setClubs((prev) => prev.filter((x) => x !== c))}
-            onQueryChange={handleClubQuery}
-            serverSearch
           />
         </section>
 

--- a/src/app/profile/components/PreferencesSection.test.js
+++ b/src/app/profile/components/PreferencesSection.test.js
@@ -1,0 +1,38 @@
+import { splitUserInterests } from './PreferencesSection';
+
+describe('splitUserInterests', () => {
+  test('separates broad categories from subcategories', () => {
+    const input = ["Arts & Media", "Dance", "Pre-Law", "Academic & Pre-Professional"];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toEqual(["Arts & Media", "Academic & Pre-Professional"]);
+    expect(subcategories).toEqual(["Dance", "Pre-Law"]);
+  });
+
+  test('handles empty array', () => {
+    const { broadCategories, subcategories } = splitUserInterests([]);
+    expect(broadCategories).toEqual([]);
+    expect(subcategories).toEqual([]);
+  });
+
+  test('handles all broad categories', () => {
+    const input = [
+      "Academic & Pre-Professional",
+      "Cultural & Identity-Based",
+      "Community & Advocacy",
+      "Arts & Media",
+      "Health & Wellness",
+      "Spiritual & Religious",
+      "Campus Life & Social",
+    ];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toHaveLength(7);
+    expect(subcategories).toHaveLength(0);
+  });
+
+  test('handles all subcategories (nothing matching broad categories)', () => {
+    const input = ["Pre-Law", "Dance", "Jewish"];
+    const { broadCategories, subcategories } = splitUserInterests(input);
+    expect(broadCategories).toHaveLength(0);
+    expect(subcategories).toHaveLength(3);
+  });
+});

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -9,6 +9,7 @@ import ReviewCard from "../components/reviewCard";
 import LoadingScreen from "../components/LoadingScreen";
 import ConfirmationModal from "../components/confirmationModal";
 import Button from "../components/button";
+import PreferencesSection from "./components/PreferencesSection";
 
 function ProfilePage() {
     const router = useRouter();
@@ -26,6 +27,8 @@ function ProfilePage() {
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
     const [reviewToDelete, setReviewToDelete] = useState(null);
     const [unreadRejectedCount, setUnreadRejectedCount] = useState(0);
+    const [preferencesExpanded, setPreferencesExpanded] = useState(false);
+    const [profilePreferences, setProfilePreferences] = useState(null);
 
     // Authentication check
     useEffect(() => {
@@ -71,6 +74,7 @@ function ProfilePage() {
                 if (!userProfile) {
                     setLoading(true);
                 }
+                setProfilePreferences(null);
 
                 // No userId param needed - API gets it from session cookies
                 const response = await fetch(`/api/profile`);
@@ -90,6 +94,12 @@ function ProfilePage() {
                     setPendingReviews(data.pendingReviews || []);
                     setRejectedReviews(data.rejectedReviews || []);
                     setUnreadRejectedCount(data.unreadRejectedCount || 0);
+                    setProfilePreferences({
+                        majors: data.profile?.majors || [],
+                        minors: data.profile?.minors || [],
+                        currentClubs: data.profile?.current_clubs || [],
+                        userInterests: data.userInterests || [],
+                    });
 
                     // Set clubs
                     setLikedClubs(data.likedClubs || []);
@@ -428,6 +438,18 @@ function ProfilePage() {
                     </div>
                 );
 
+            case "preferences":
+                return profilePreferences ? (
+                    <PreferencesSection
+                        majors={profilePreferences.majors}
+                        minors={profilePreferences.minors}
+                        currentClubs={profilePreferences.currentClubs}
+                        userInterests={profilePreferences.userInterests}
+                    />
+                ) : (
+                    <LoadingScreen />
+                );
+
             default:
                 return null;
         }
@@ -582,6 +604,48 @@ function ProfilePage() {
                                             {item.label}
                                         </button>
                                     ))}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Preferences Section */}
+                        <div className="mt-4">
+                            <button
+                                onClick={() => setPreferencesExpanded(!preferencesExpanded)}
+                                className="mb-2 flex w-full items-center justify-between text-left font-semibold"
+                            >
+                                <div className="flex items-center gap-2">
+                                    <img
+                                        src="/edit-2.svg"
+                                        alt="preferences icon"
+                                        className="max-w-[20px]"
+                                    />
+                                    <span className="text-2xl">Preferences</span>
+                                </div>
+                                <svg
+                                    className={`h-4 w-4 transition-transform ${preferencesExpanded ? "rotate-180" : ""}`}
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M19 9l-7 7-7-7"
+                                    />
+                                </svg>
+                            </button>
+
+                            {preferencesExpanded && (
+                                <div className="relative ml-2 space-y-1">
+                                    <div className="absolute top-0 bottom-0 left-0 w-px bg-gray-300"></div>
+                                    <button
+                                        onClick={() => setActiveSection("preferences")}
+                                        className={`ml-3 block w-full text-left text-[#6E808D] font-medium py-2 px-3 rounded-full relative ${activeSection === "preferences" ? "bg-[#F0F2F9]" : "hover:bg-[#F0F2F9]"}`}
+                                    >
+                                        Edit Preferences
+                                    </button>
                                 </div>
                             )}
                         </div>

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -27,7 +27,6 @@ function ProfilePage() {
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
     const [reviewToDelete, setReviewToDelete] = useState(null);
     const [unreadRejectedCount, setUnreadRejectedCount] = useState(0);
-    const [preferencesExpanded, setPreferencesExpanded] = useState(false);
     const [profilePreferences, setProfilePreferences] = useState(null);
 
     // Authentication check
@@ -51,7 +50,9 @@ function ProfilePage() {
         const { data: authListener } = supabase.auth.onAuthStateChange(
             (_event, session) => {
                 if (session?.user) {
-                    setCurrentUser(session.user);
+                    setCurrentUser((prev) =>
+                        prev?.id === session.user.id ? prev : session.user
+                    );
                 } else {
                     setCurrentUser(null);
                     window.location.href = "/sign-in";
@@ -74,7 +75,6 @@ function ProfilePage() {
                 if (!userProfile) {
                     setLoading(true);
                 }
-                setProfilePreferences(null);
 
                 // No userId param needed - API gets it from session cookies
                 const response = await fetch(`/api/profile`);
@@ -611,8 +611,8 @@ function ProfilePage() {
                         {/* Preferences Section */}
                         <div className="mt-4">
                             <button
-                                onClick={() => setPreferencesExpanded(!preferencesExpanded)}
-                                className="mb-2 flex w-full items-center justify-between text-left font-semibold"
+                                onClick={() => setActiveSection("preferences")}
+                                className={`mb-2 flex w-full items-center justify-between text-left font-semibold rounded-full px-2 py-1 ${activeSection === "preferences" ? "bg-[#F0F2F9]" : "hover:bg-[#F0F2F9]"}`}
                             >
                                 <div className="flex items-center gap-2">
                                     <img
@@ -622,32 +622,7 @@ function ProfilePage() {
                                     />
                                     <span className="text-2xl">Preferences</span>
                                 </div>
-                                <svg
-                                    className={`h-4 w-4 transition-transform ${preferencesExpanded ? "rotate-180" : ""}`}
-                                    fill="none"
-                                    stroke="currentColor"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M19 9l-7 7-7-7"
-                                    />
-                                </svg>
                             </button>
-
-                            {preferencesExpanded && (
-                                <div className="relative ml-2 space-y-1">
-                                    <div className="absolute top-0 bottom-0 left-0 w-px bg-gray-300"></div>
-                                    <button
-                                        onClick={() => setActiveSection("preferences")}
-                                        className={`ml-3 block w-full text-left text-[#6E808D] font-medium py-2 px-3 rounded-full relative ${activeSection === "preferences" ? "bg-[#F0F2F9]" : "hover:bg-[#F0F2F9]"}`}
-                                    >
-                                        Edit Preferences
-                                    </button>
-                                </div>
-                            )}
                         </div>
                     </div>
                 </div>

--- a/src/app/utils/splitUserInterests.js
+++ b/src/app/utils/splitUserInterests.js
@@ -1,0 +1,9 @@
+import INTERESTS from "../onboarding/data/interests.json";
+
+const BROAD_CATEGORIES = Object.keys(INTERESTS);
+
+export function splitUserInterests(interests, broadCategories = BROAD_CATEGORIES) {
+  const broad = interests.filter((i) => broadCategories.includes(i));
+  const sub = interests.filter((i) => !broadCategories.includes(i));
+  return { broadCategories: broad, subcategories: sub };
+}

--- a/src/app/utils/splitUserInterests.test.js
+++ b/src/app/utils/splitUserInterests.test.js
@@ -1,4 +1,4 @@
-import { splitUserInterests } from './PreferencesSection';
+import { splitUserInterests } from './splitUserInterests';
 
 describe('splitUserInterests', () => {
   test('separates broad categories from subcategories', () => {


### PR DESCRIPTION
tackling issue #312

Summary

  - Adds a Preferences section to the profile page sidebar where users can update their majors/minors, current clubs, and interest categories/subcategories after completing onboarding
  - Finishes the Interests.js onboarding step (was placeholder) and fixes Clubs.js to use live debounced search against /api/clubs instead of a hardcoded list
  - Adds PATCH /api/onboarding to update profile preferences without touching onboarding_completed, and extends GET /api/profile to return userInterests
  - Introduces src/app/onboarding/data/interests.json as the single source of truth for the 7 broad interest categories and their subcategories, shared between onboarding and the profile editor

Test Plan

  - Complete onboarding and verify Clubs step shows live search results
  - Complete onboarding and verify Interests step shows subcategories filtered by selected categories
  - Visit profile page, open Preferences section — verify pre-filled with saved values
  - Change majors/categories and save — confirm changes persist on reload
  - Verify Save button is disabled with fewer than 1 major or fewer than 2 categories selected