### PR TITLE
Charlton/reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ CLAUDE.md
 
 # production
 /build
+/docs/superpowers
 
 # misc
 .DS_Store

--- a/src/app/api/approvedReviews/[id]/route.js
+++ b/src/app/api/approvedReviews/[id]/route.js
@@ -1,4 +1,4 @@
-import { createAuthenticatedClient, supabaseServer } from "@/app/lib/server-db";
+import { createAuthenticatedClient } from "@/app/lib/server-db";
 
 export async function GET(req, { params }) {
   const { id } = await params;
@@ -104,7 +104,7 @@ export async function POST(req, { params }) {
       return new Response(JSON.stringify({ error: "Error resubmitting review" }), { status: 500 });
     }
 
-    const { error: deleteError } = await supabaseServer
+    const { error: deleteError } = await supabase
       .from("reviews")
       .delete()
       .eq("id", id);

--- a/src/app/api/approvedReviews/[id]/route.js
+++ b/src/app/api/approvedReviews/[id]/route.js
@@ -1,0 +1,122 @@
+import { createAuthenticatedClient } from "@/app/lib/server-db";
+
+export async function GET(req, { params }) {
+  const { id } = await params;
+
+  try {
+    const supabase = await createAuthenticatedClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+    }
+
+    const { data: review, error: reviewError } = await supabase
+      .from("reviews")
+      .select("*")
+      .eq("id", id)
+      .single();
+
+    if (reviewError || !review) {
+      return new Response(JSON.stringify({ error: "Review not found" }), { status: 404 });
+    }
+
+    if (review.user_id !== user.id) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+    }
+
+    return new Response(JSON.stringify({ review }), { status: 200 });
+  } catch (error) {
+    console.error("Unexpected error in approved review GET:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}
+
+export async function POST(req, { params }) {
+  const { id } = await params;
+
+  try {
+    const supabase = await createAuthenticatedClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+    }
+
+    const { data: existingReview, error: fetchError } = await supabase
+      .from("reviews")
+      .select("user_id, user_alias")
+      .eq("id", id)
+      .single();
+
+    if (fetchError || !existingReview) {
+      return new Response(JSON.stringify({ error: "Review not found" }), { status: 404 });
+    }
+
+    if (existingReview.user_id !== user.id) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+    }
+
+    let body;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid request body" }), { status: 400 });
+    }
+
+    const {
+      club_id,
+      club_name,
+      membership_start_quarter,
+      membership_start_year,
+      membership_end_quarter,
+      membership_end_year,
+      time_commitment_rating,
+      inclusivity_rating,
+      social_community_rating,
+      competitiveness_rating,
+      overall_satisfaction,
+      review_text,
+    } = body;
+
+    const { error: insertError } = await supabase
+      .from("pending_reviews")
+      .insert({
+        club_id,
+        club_name,
+        user_id: user.id,
+        user_email: user.email,
+        membership_start_quarter,
+        membership_start_year,
+        membership_end_quarter,
+        membership_end_year,
+        time_commitment_rating,
+        inclusivity_rating,
+        social_community_rating,
+        competitiveness_rating,
+        overall_satisfaction,
+        review_text,
+        user_alias: existingReview.user_alias,
+      });
+
+    if (insertError) {
+      console.error("Error inserting into pending reviews:", insertError);
+      return new Response(JSON.stringify({ error: "Error resubmitting review" }), { status: 500 });
+    }
+
+    const { error: deleteError } = await supabase
+      .from("reviews")
+      .delete()
+      .eq("id", id);
+
+    if (deleteError) {
+      console.error("Error deleting from reviews:", deleteError);
+      return new Response(JSON.stringify({ error: "Error removing approved review" }), { status: 500 });
+    }
+
+    return new Response(JSON.stringify({ message: "Review resubmitted for approval" }), { status: 200 });
+  } catch (error) {
+    console.error("Unexpected error in approved review POST:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}

--- a/src/app/api/approvedReviews/[id]/route.js
+++ b/src/app/api/approvedReviews/[id]/route.js
@@ -1,4 +1,4 @@
-import { createAuthenticatedClient } from "@/app/lib/server-db";
+import { createAuthenticatedClient, supabaseServer } from "@/app/lib/server-db";
 
 export async function GET(req, { params }) {
   const { id } = await params;
@@ -104,7 +104,7 @@ export async function POST(req, { params }) {
       return new Response(JSON.stringify({ error: "Error resubmitting review" }), { status: 500 });
     }
 
-    const { error: deleteError } = await supabase
+    const { error: deleteError } = await supabaseServer
       .from("reviews")
       .delete()
       .eq("id", id);

--- a/src/app/api/rejectedReviews/[id]/route.js
+++ b/src/app/api/rejectedReviews/[id]/route.js
@@ -1,4 +1,4 @@
-import { createAuthenticatedClient } from "@/app/lib/server-db";
+import { createAuthenticatedClient, supabaseServer } from "@/app/lib/server-db";
 
 export async function GET(req, { params }) {
 	const { id } = await params;
@@ -6,79 +6,118 @@ export async function GET(req, { params }) {
 	try {
 		const supabase = await createAuthenticatedClient();
 
+		const { data: { user }, error: authError } = await supabase.auth.getUser();
+		if (authError || !user) {
+			return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+		}
+
 		const { data: review, error: reviewError } = await supabase
 			.from('rejected_reviews')
 			.select('*')
 			.eq('id', id)
 			.single();
 
-		if (reviewError) {
-			console.error('Error fetching rejected review:', reviewError);
-			return new Response(
-				JSON.stringify({ error: "Error fetching rejected review" }),
-				{ status: 500 }
-			);
+		if (reviewError || !review) {
+			return new Response(JSON.stringify({ error: "Review not found" }), { status: 404 });
+		}
+
+		if (review.user_id !== user.id) {
+			return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
 		}
 
 		return new Response(JSON.stringify({ review }), { status: 200 });
 	} catch (error) {
-		console.error('Unexpected error in rejected review API:', error);
-		return new Response(
-			JSON.stringify({ error: "Internal Server Error" }),
-			{ status: 500 }
-		);
+		console.error('Unexpected error in rejected review GET:', error);
+		return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
 	}
 }
 
-// move edited rejected review to pending reviews
 export async function POST(req, { params }) {
-
 	const { id } = await params;
-	const body = await req.json();
 
 	try {
-
 		const supabase = await createAuthenticatedClient();
 
-		// insert new review into pending reviews
+		const { data: { user }, error: authError } = await supabase.auth.getUser();
+		if (authError || !user) {
+			return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+		}
+
+		const { data: existingReview, error: fetchError } = await supabase
+			.from('rejected_reviews')
+			.select('user_id, user_alias')
+			.eq('id', id)
+			.single();
+
+		if (fetchError || !existingReview) {
+			return new Response(JSON.stringify({ error: "Review not found" }), { status: 404 });
+		}
+
+		if (existingReview.user_id !== user.id) {
+			return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+		}
+
+		let body;
+		try {
+			body = await req.json();
+		} catch {
+			return new Response(JSON.stringify({ error: "Invalid request body" }), { status: 400 });
+		}
+
+		const {
+			club_id,
+			club_name,
+			membership_start_quarter,
+			membership_start_year,
+			membership_end_quarter,
+			membership_end_year,
+			time_commitment_rating,
+			inclusivity_rating,
+			social_community_rating,
+			competitiveness_rating,
+			overall_satisfaction,
+			review_text,
+		} = body;
+
 		const { error: insertError } = await supabase
 			.from('pending_reviews')
-			.insert(body)
-			.select()
-			.single();
+			.insert({
+				club_id,
+				club_name,
+				user_id: user.id,
+				user_email: user.email,
+				membership_start_quarter,
+				membership_start_year,
+				membership_end_quarter,
+				membership_end_year,
+				time_commitment_rating,
+				inclusivity_rating,
+				social_community_rating,
+				competitiveness_rating,
+				overall_satisfaction,
+				review_text,
+				user_alias: existingReview.user_alias,
+			});
 
 		if (insertError) {
 			console.error('Error inserting into pending reviews:', insertError);
-			return new Response(
-				JSON.stringify({ error: "Error resubmitting rejected review" }),
-				{ status: 500 }
-			);
+			return new Response(JSON.stringify({ error: "Error resubmitting rejected review" }), { status: 500 });
 		}
 
-		// delete from rejected reviews
-		const { error: deleteError } = await supabase
+		const { error: deleteError } = await supabaseServer
 			.from('rejected_reviews')
 			.delete()
 			.eq('id', id);
 
 		if (deleteError) {
 			console.error('Error deleting from rejected reviews:', deleteError);
-			return new Response(
-				JSON.stringify({ error: "Error cleaning up rejected review" }),
-				{ status: 500 }
-			);
+			return new Response(JSON.stringify({ error: "Error cleaning up rejected review" }), { status: 500 });
 		}
 
-		return new Response(JSON.stringify(
-			{ message: "Rejected review successfully resubmitted for approval" }
-		), { status: 200 });
-
+		return new Response(JSON.stringify({ message: "Rejected review successfully resubmitted for approval" }), { status: 200 });
 	} catch (error) {
 		console.error('Unexpected error in resubmitting rejected review API:', error);
-		return new Response(
-			JSON.stringify({ error: "Internal Server Error" }),
-			{ status: 500 }
-		);
+		return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
 	}
 }
 

--- a/src/app/api/rejectedReviews/[id]/route.js
+++ b/src/app/api/rejectedReviews/[id]/route.js
@@ -1,4 +1,4 @@
-import { createAuthenticatedClient, supabaseServer } from "@/app/lib/server-db";
+import { createAuthenticatedClient } from "@/app/lib/server-db";
 
 export async function GET(req, { params }) {
 	const { id } = await params;
@@ -104,7 +104,7 @@ export async function POST(req, { params }) {
 			return new Response(JSON.stringify({ error: "Error resubmitting rejected review" }), { status: 500 });
 		}
 
-		const { error: deleteError } = await supabaseServer
+		const { error: deleteError } = await supabase
 			.from('rejected_reviews')
 			.delete()
 			.eq('id', id);

--- a/src/app/components/reviewCard.js
+++ b/src/app/components/reviewCard.js
@@ -121,7 +121,7 @@ export default function ReviewCard({
 
   // Determine what actions are available based on status
   const canLike = status === "displayed" && onLike;
-  const canEdit = status === "rejected" && onEdit;
+  const canEdit = (status === "rejected" || status === "approved") && onEdit;
   const canDelete = status === "rejected" && onDelete;
 
   const cardContent = (

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -100,10 +100,8 @@ function ProfilePage() {
         console.log('Like review:', reviewId, isLiked);
     };
 
-    const handleEdit = (review) => {
-        // Navigate to edit page
-        console.log('Editing review:', review);
-        router.push(`/review/edit/${review.id}`);
+    const handleEdit = (review, source) => {
+        router.push(`/review/edit/${review.id}?source=${source}`);
     };
 
     const handleDelete = async (reviewId) => {
@@ -242,7 +240,7 @@ function ProfilePage() {
                                         status="approved"
                                         clickable={true}
                                         onLike={handleLike}
-                                        onEdit={handleEdit}
+                                        onEdit={(review) => handleEdit(review, "approved")}
                                         onDelete={handleDelete}
                                     />
                                 ))}
@@ -311,7 +309,7 @@ function ProfilePage() {
                                         status="rejected"
                                         clickable={true}
                                         onLike={handleLike}
-                                        onEdit={handleEdit}
+                                        onEdit={(review) => handleEdit(review, "rejected")}
                                         onDelete={handleDelete}
                                     />
                                 ))}

--- a/src/app/review/edit/[id]/page.js
+++ b/src/app/review/edit/[id]/page.js
@@ -7,7 +7,7 @@ import { QuarterYearDropdown } from "../../../components/dropdowns";
 import CustomSlider from "../../../components/custom-slider";
 import { supabase } from "../../../lib/db";
 import { useRequireAuth } from "../../../context/AuthContext";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { AiFillStar } from "react-icons/ai";
 import Tooltip from "../../../components/tooltip";
@@ -45,9 +45,11 @@ const getCurrentQuarter = () => {
 export default function EditReviewPage() {
 	const params = useParams();
 	const id = params.id;
-
 	const router = useRouter();
 	const { user } = useRequireAuth();
+	const searchParams = useSearchParams();
+	const rawSource = searchParams.get("source");
+	const source = rawSource === "approved" ? "approved" : "rejected";
 
 	const [selectedClub, setSelectedClub] = useState("");
 	const [clubId, setClubId] = useState(null);
@@ -75,17 +77,18 @@ export default function EditReviewPage() {
 	const [success, setSuccess] = useState(false);
 	const [userAlias, setUserAlias] = useState("");
 
-	// Get rejected review and set form fields
+	// Get review data and set form fields
 	useEffect(() => {
 		if (!id) {
 			setIsReviewLoading(false);
 			return;
 		}
 
-		const fetchRejectedReview = async () => {
+		const fetchReview = async () => {
 
 			try {
-				const response = await fetch(`/api/rejectedReviews/${id}`, {
+				const apiBase = source === "approved" ? "approvedReviews" : "rejectedReviews";
+				const response = await fetch(`/api/${apiBase}/${id}`, {
 					method: 'GET',
 					headers: { 'Content-Type': 'application/json' },
 				});
@@ -124,9 +127,9 @@ export default function EditReviewPage() {
 
 		};
 
-		fetchRejectedReview();
+		fetchReview();
 
-	}, [id]);
+	}, [id, source]);
 
 	useEffect(() => {
 		if (startQuarter && startYear && endQuarter && endYear) {
@@ -253,7 +256,8 @@ export default function EditReviewPage() {
 				user_alias: userAlias,
 			};
 
-			const response = await fetch(`/api/rejectedReviews/${id}`, {
+			const apiBase = source === "approved" ? "approvedReviews" : "rejectedReviews";
+			const response = await fetch(`/api/${apiBase}/${id}`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(reviewData),
@@ -613,6 +617,12 @@ export default function EditReviewPage() {
 							{reviewText.length} / 2500 Characters
 						</div>
 					</div>
+
+					{source === "approved" && (
+						<p className="text-sm text-amber-600 mb-4">
+							Submitting will unpublish your review until it&apos;s re-approved by our team.
+						</p>
+					)}
 
 					{error && (
 						<div className="mb-4 rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700">

--- a/supabase/migrations/004_reviews_owner_delete_policy.sql
+++ b/supabase/migrations/004_reviews_owner_delete_policy.sql
@@ -1,0 +1,11 @@
+-- Allow users to delete their own approved reviews so they can edit
+-- and resubmit them through the pending_reviews queue.
+alter table public.reviews enable row level security;
+
+drop policy if exists "Users can delete their own reviews" on public.reviews;
+
+create policy "Users can delete their own reviews"
+  on public.reviews
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
Issue #367 

  Allow users to edit approved and rejected reviews

  Users can now edit any of their own reviews from the profile page and resubmit them through the admin approval queue.

  What changed
  
  New feature: edit approved reviews
  - Approved reviews now show an Edit button on the profile page alongside rejected ones
  - Editing an approved review unpublishes it immediately and moves it to the pending queue for re-approval
  - A warning is shown on the edit form so users know their review will go offline until re-approved
  - New API route POST /api/approvedReviews/[id] handles the move from reviews → pending_reviews

  Bug fix: duplicate reviews on resubmit

  When a user submitted an edited review, the original approved review was not being removed because the reviews table
  had no RLS policy allowing owners to delete their own rows. The pending review would then get approved and land
  alongside the original, creating a duplicate.

  Fixed properly by adding an owner-scoped DELETE policy on reviews (auth.uid() = user_id) and using the authenticated
  Supabase client for the delete — RLS enforces ownership rather than the API route bypassing it with the service role.

  Security hardening on rejectedReviews/[id] route
  - Added authentication and ownership checks to GET and POST (previously unauthenticated callers could fetch or
  resubmit any review by ID) 
  - Replaced raw body passthrough on POST with an explicit field whitelist; user_id, user_email, and user_alias are now
   sourced from the auth session and database row rather than the request body

  Files changed

  - supabase/migrations/004_reviews_owner_delete_policy.sql — new RLS policy allowing review owners to delete their own
   rows
  - src/app/api/approvedReviews/[id]/route.js — new route; delete goes through authenticated client + RLS, not service
  role
  - src/app/api/rejectedReviews/[id]/route.js — security hardening
  - src/app/review/edit/[id]/page.js — reads ?source= param, routes to correct API, shows unpublish warning
  - src/app/profile/page.js — passes source param when navigating to edit
  - src/app/components/reviewCard.js — enables Edit button for approved reviews

  Migration note

  Apply 004_reviews_owner_delete_policy.sql before deploying, otherwise the delete on resubmit will silently fail under
   RLS and the duplicate-review bug will return.