### PR TITLE
Chris/category search center

### DIFF
--- a/src/app/components/filter.js
+++ b/src/app/components/filter.js
@@ -70,6 +70,7 @@ export default function Filter({
   const [isMobile, setIsMobile] = useState(false);
   const filterRef = useRef(null);
   const buttonRef = useRef(null);
+  const hasOpenedOnce = useRef(false);
   const router = useRouter();
 
   // Sync with context state
@@ -128,11 +129,16 @@ export default function Filter({
       return;
     }
 
+    // timeout to make sure other screen elements have rendered
+    // otherwise they might show up after and cover the filter
+
+    // on the first time loading, we might have to wait for more elements to load,
+    // so add a longer delay
+    const delay = hasOpenedOnce.current ? 50 : 2000;
     const t = setTimeout(() => {
-      if (filterRef.current) {
-        filterRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
-      }
-    }, 100);
+      filterRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+      hasOpenedOnce.current = true;
+    }, delay);
     return () => clearTimeout(t);
   }, [isMobile, showFilter]);
 

--- a/src/app/components/filter.js
+++ b/src/app/components/filter.js
@@ -120,17 +120,20 @@ export default function Filter({
     return () => {
       document.body.style.overflow = "";
     };
+
   }, [isMobile, showFilter]);
 
   useEffect(() => {
-    if (isMobile && showFilter) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
+    if (!showFilter || isMobile) {
+      return;
     }
-    return () => {
-      document.body.style.overflow = "";
-    };
+
+    const t = setTimeout(() => {
+      if (filterRef.current) {
+        filterRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }, 100);
+    return () => clearTimeout(t);
   }, [isMobile, showFilter]);
 
   const toggleTag = (tag) => {


### PR DESCRIPTION
Not sure if this was the right solution for this problem, but some page elements do not load until a certain amount of time (i.e. checking to see if the user has completed onboarding requires requesting from the backend and takes a little time to load), so if you click more categories from the home page, you need a bit of a delay to make sure the filter doesn't get scrolled in too early.

https://github.com/user-attachments/assets/9264f78b-95d9-4152-ac26-5301162b8f91

